### PR TITLE
probe type should not include cluster name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recommendations-broker",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "description": "Akkeris recommendations broker",
   "main": "index.js",
   "scripts": {

--- a/services/turbonomic/utils.js
+++ b/services/turbonomic/utils.js
@@ -39,7 +39,7 @@ async function searchForApp(app, space, cluster, turboCookie) {
   const params = {
     regex: true,
     types: 'WorkloadController',
-    probe_types: `Kubernetes-${cluster}`,
+    probe_types: 'Kubernetes',
     q: `${app}(--.*)?`, // (--.*)? indicates include all formation types in the search
   };
 
@@ -47,6 +47,9 @@ async function searchForApp(app, space, cluster, turboCookie) {
     let { data: searchResults } = await axios.get(searchEndpoint, {
       params, headers: { Cookie: turboCookie },
     });
+
+    // Filter by cluster
+    searchResults = searchResults.filter((wc) => wc.discoveredBy.displayName === `Kubernetes-${cluster}`);
 
     // Filter by namespace
     searchResults = searchResults.filter((wc) => (


### PR DESCRIPTION
Filter by cluster after the search instead of using the cluster name as part of the probe type (which does not work in 8.1.4)